### PR TITLE
Prevent users from editing events Habit3 didn't create

### DIFF
--- a/front/src/Rock.tsx
+++ b/front/src/Rock.tsx
@@ -17,8 +17,8 @@ const Rock = ({ rock, isEditing, updateRockText, deleteRock }) => {
 
   return (
     <div className="rock d-flex align-items-center mb-2" data-key={rock.id}>
-      {isEditing ? (
-        <>
+      {isEditing ? 
+        <div className='input-group'>
           <input
             type="text"
             value={rock.text}
@@ -26,14 +26,17 @@ const Rock = ({ rock, isEditing, updateRockText, deleteRock }) => {
             className="form-control"
           />
           <button className="btn btn-danger btn-sm ml-2" onClick={deleteRock}>
-            Delete
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-trash" viewBox="0 0 16 16">
+              <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z" />
+              <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z" />
+            </svg>
           </button>
-        </>
-      ) : (
+        </div>
+        : 
         <p ref={drag} className="draggable">
           {rock.text}
         </p>
-      )}
+      }
     </div>
   );
 };

--- a/front/src/Role.tsx
+++ b/front/src/Role.tsx
@@ -16,21 +16,24 @@ const Role = ({ role, isEditing, dispatch }) => {
   return (
     <div className="role mb-3">
       <div className="role-header d-flex justify-content-between align-items-center mb-2">
-        {isEditing ? (
-          <input
-            type="text"
-            value={role.roleTitle}
-            onChange={handleTitleChange}
-            className="form-control"
-          />
-        ) : (
+        {isEditing ?
+          <div className='input-group'>
+            <input
+              type="text"
+              value={role.roleTitle}
+              onChange={handleTitleChange}
+              className="form-control"
+            />
+            <button className="btn btn-danger btn-sm ml-2" onClick={() => dispatch(deleteRoleAction(role.id))}>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-trash" viewBox="0 0 16 16">
+                <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z" />
+                <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z" />
+              </svg>
+            </button>
+          </div>
+          :
           <span className="font-weight-bold">{role.roleTitle}</span>
-        )}
-        {isEditing && (
-          <button className="btn btn-danger btn-sm ml-2" onClick={() => dispatch(deleteRoleAction(role.id))}>
-            Delete Role
-          </button>
-        )}
+        }
       </div>
       <div className="role-rocks">
         {role.rocks.map(rock => (

--- a/front/src/app.tsx
+++ b/front/src/app.tsx
@@ -58,7 +58,7 @@ function App({ initialRoles }) {
         console.log("user:", user);
         setUser(user);
         rolesAppt = tu.apptFromGEvent(rolesEvent)
-        dispatch(replaceAllRoles(rolesAppt));
+        dispatch(replaceAllRoles(rolesAppt.description));
       } else {
         console.log("Schedule fetch retry for later.");
         setTimeout(fetchWhenReady, 500);
@@ -86,6 +86,7 @@ function App({ initialRoles }) {
     gcal.handleSignoutClick();
     setAppts(noAppts);
     setUser(noUser);
+    dispatch(replaceAllRoles("[]"));
     // setTimeout(syncGoogle, 1000);
     syncGoogle();
   }

--- a/front/src/calendar/Appointment.tsx
+++ b/front/src/calendar/Appointment.tsx
@@ -63,7 +63,12 @@ export default function Appointment({ appt, dayStart, depth, position, dayDimens
   const top_str = topVal.toString() + 'px';
   const width_str = dayDimensions.width.toString() + 'px';
 
-  return (
+
+  return (appt.rockId === "") ?
+    <div className="appointment immutable" style={{ top: top_str, height: height_str, width: width_str }}>
+      <span>{appt.summary}</span>
+    </div>
+    :
     <div className="appointment" style={{ top: top_str, height: height_str, width: width_str }}>
       <div ref={dragAppt} className="draggable">
         <span>{appt.summary}</span>
@@ -80,5 +85,4 @@ export default function Appointment({ appt, dayStart, depth, position, dayDimens
         </svg>
       </div>
     </div>
-  )
 }

--- a/front/src/calendar/Calendar.css
+++ b/front/src/calendar/Calendar.css
@@ -95,9 +95,15 @@
   position: absolute;
   z-index: 1;
   background-color: #e8ffda;
+  border-color: darkblue;
   border-style: solid solid solid solid;
   border-radius: 6px;
   text-align: center;
+}
+
+.immutable{
+  background-color: lightgrey;
+  border-color: darkslategrey;
 }
 
 .appointment .draggable{

--- a/front/src/calendar/Day.tsx
+++ b/front/src/calendar/Day.tsx
@@ -33,7 +33,7 @@ export default function Day({ dayIndex, appts, addAppt, updateApptTime, deleteAp
     switch (monitor.getItemType()) {
       case "rock": {
         console.log("rock dropped");
-        const newAppt = new ts.Appt(item.text, { hours: pointerYInDay / 40 }, dayStart);
+        const newAppt = new ts.Appt(item.text, { hours: pointerYInDay / 40, rockId: item.id}, dayStart);
         addAppt(newAppt);
         break;
       }

--- a/front/src/rolesReducer.tsx
+++ b/front/src/rolesReducer.tsx
@@ -28,12 +28,8 @@ export default function rolesReducer(roles, action) {
     case "addRock": {
       return roles.map(role => {
         if (role.id === action.roleId) {
-
-          // Find the highest rock ID in this role.
-          const maxRockId = role.rocks.reduce((maxRockId, rock) => Math.max(maxRockId, rock.id), 1);
-          // The new rock should have one above that. 
-          const newRockId = maxRockId + 1;
-          const newRock = { id: newRockId, text: `Rock ${newRockId}` };
+          const newRockId = crypto.randomUUID();
+          const newRock = { id: newRockId, text: "New Rock" };
           return { ...role, rocks: [...role.rocks, newRock] };
         }
         return role;

--- a/front/src/rolesReducer.tsx
+++ b/front/src/rolesReducer.tsx
@@ -1,6 +1,3 @@
-import { Appt } from "./calendar/utils/timeUtils";
-
-let localRolesAppt: Appt;
 
 export default function rolesReducer(roles, action) {
   switch (action.type) {
@@ -62,10 +59,9 @@ export default function rolesReducer(roles, action) {
   }
 }
 
-export function replaceAllRoles(fetchedRolesAppt: Appt) {
-  console.log("replaceAllRoles", fetchedRolesAppt);
-  localRolesAppt = fetchedRolesAppt;
-  const newRoles = JSON.parse(fetchedRolesAppt.description);
+export function replaceAllRoles(rolesJSON) {
+  const newRoles = JSON.parse(rolesJSON);
+  console.log("replaceAllRoles", newRoles);
   return { type: "replaceAll", newRoles, skipSync: true };
 }
 


### PR DESCRIPTION
Google calendar API currently has a limitation that makes it impossible for an app like Habit3 to make edits to an event on behalf of a guest to an event (an event that a different user created, but that you are invited to).  Of course, this is possible in the Google calendar web UI so long as guests have permission to edit the event, but that permission is not honored via the API.  
The consequence, is that if Habit3 edits these events, they only update for the Habit3 user (you), but not for the event creator or any other guests.  (!!!)  Further, you don't get a notice about that.  (!!!!!)  Since this would induce you, the Habit3 user, to miss appointments, I have simply prevented Habit3 from being able to make any edits to events that didn't originally come from rocks.  

In future versions, I will allow edits to events that you own (via opting-in to edit owned events), since they don't pose a risk of missing events.  For now, I'm playing it safe.